### PR TITLE
Remove redundant gradleApi

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,10 +55,6 @@ mavenPublishing {
   }
 }
 
-dependencies {
-  compileOnly gradleApi()
-}
-
 test {
   useJUnitPlatform()
 }


### PR DESCRIPTION
It's added into `api` by `java-gradle-plugin`.